### PR TITLE
Render link to "parent template part" (if it exists)

### DIFF
--- a/lib/inventree/part.dart
+++ b/lib/inventree/part.dart
@@ -305,6 +305,9 @@ class InvenTreePart extends InvenTreeModel {
 
     String get units => (jsondata["units"] ?? "") as String;
 
+    // Get the ID of the Part that this part is a variant of (or null)
+    int? get variantOf => jsondata["variant_of"] as int?;
+
     // Get the number of units being build for this Part
     double get building => double.tryParse(jsondata["building"].toString()) ?? 0;
 

--- a/lib/widget/part_detail.dart
+++ b/lib/widget/part_detail.dart
@@ -37,6 +37,8 @@ class _PartDisplayState extends RefreshableState<PartDetailWidget> {
 
   InvenTreePart part;
 
+  InvenTreePart? parentPart;
+
   @override
   String getAppBarTitle(BuildContext context) => L10().partDetails;
 
@@ -90,6 +92,21 @@ class _PartDisplayState extends RefreshableState<PartDetailWidget> {
     if (!result || part.pk == -1) {
       // Part could not be loaded, for some reason
       Navigator.of(context).pop();
+    }
+
+    // If the part points to a parent "template" part, request that too
+    int? templatePartId = part.variantOf;
+
+    if (templatePartId == null) {
+      parentPart = null;
+    } else {
+      final result = await InvenTreePart().get(templatePartId);
+
+      if (result != null && result is InvenTreePart) {
+        parentPart = result;
+      } else {
+        parentPart = null;
+      }
     }
 
     await part.getTestTemplates();
@@ -178,6 +195,26 @@ class _PartDisplayState extends RefreshableState<PartDetailWidget> {
               FontAwesomeIcons.exclamationCircle,
               color: COLOR_DANGER
           ),
+        )
+      );
+    }
+
+    if (parentPart != null) {
+      tiles.add(
+        ListTile(
+          title: Text(L10().templatePart),
+          subtitle: Text(parentPart!.fullname),
+          leading: InvenTreeAPI().getImage(
+            parentPart!.thumbnail,
+            width: 32,
+            height: 32,
+          ),
+          onTap: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (context) => PartDetailWidget(parentPart!))
+            );
+          }
         )
       );
     }


### PR DESCRIPTION
For "variant" parts, show a link to the "parent template part" in the part detail view:

![image](https://user-images.githubusercontent.com/10080325/164259023-717bcc2f-e394-4231-8e6b-7664b9c97e4b.png)

