### PR TITLE
Prevent specific permissions from being requested

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -56,4 +56,11 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
+    <!--
+        Prevent lower level dependencies from including specific permissions.
+        Ref: https://developer.android.com/studio/build/manage-manifests
+     -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" tools:node="remove"/>
+    <uses-permission android:name="android.permission.INSTALL_PACKAGES" tools:node="remove"/>
+    
 </manifest>


### PR DESCRIPTION
open_file package requests the REQUEST_INSTALL_PACKAGES permission by default