### PR TITLE
Fix broken android manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="inventree.inventree_app">
 
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that


### PR DESCRIPTION
- Adds xmlns:tools to manifest xml file
- Ref: https://stackoverflow.com/questions/55334431/facing-below-error-toolsnode-associated-with-an-element-type-uses-permission