### PR TITLE
Supplier part support

### DIFF
--- a/assets/release_notes.md
+++ b/assets/release_notes.md
@@ -5,6 +5,7 @@
 ---
 
 - Add support for Supplier Parts
+- Updated translations
 
 ### 0.9.3 - February 2023
 ---

--- a/assets/release_notes.md
+++ b/assets/release_notes.md
@@ -1,6 +1,11 @@
 ## InvenTree App Release Notes
 ---
 
+### 0.10.0 - February 2023
+---
+
+- Add support for Supplier Parts
+
 ### 0.9.3 - February 2023
 ---
 

--- a/lib/api_form.dart
+++ b/lib/api_form.dart
@@ -5,19 +5,21 @@ import "package:intl/intl.dart";
 import "package:font_awesome_flutter/font_awesome_flutter.dart";
 import "package:dropdown_search/dropdown_search.dart";
 import "package:datetime_picker_formfield/datetime_picker_formfield.dart";
+import "package:flutter/material.dart";
 
 import "package:inventree/api.dart";
 import "package:inventree/app_colors.dart";
 import "package:inventree/barcode.dart";
 import "package:inventree/helpers.dart";
+import "package:inventree/l10.dart";
+
+import "package:inventree/inventree/company.dart";
 import "package:inventree/inventree/part.dart";
 import "package:inventree/inventree/sentry.dart";
 import "package:inventree/inventree/stock.dart";
+
 import "package:inventree/widget/dialogs.dart";
 import "package:inventree/widget/fields.dart";
-import "package:inventree/l10.dart";
-
-import "package:flutter/material.dart";
 import "package:inventree/widget/progress.dart";
 import "package:inventree/widget/snacks.dart";
 
@@ -641,6 +643,17 @@ class APIFormField {
         return ListTile(
           title: Text(name),
           leading: FaIcon(isGroup ? FontAwesomeIcons.users : FontAwesomeIcons.user),
+        );
+      case "company":
+        var company = InvenTreeCompany.fromJson(data);
+        return ListTile(
+          title: Text(company.name),
+          subtitle: extended ? Text(company.description) : null,
+          leading: InvenTreeAPI().getImage(
+            company.thumbnail,
+            width: 40,
+            height: 40
+          )
         );
       default:
         return ListTile(

--- a/lib/barcode.dart
+++ b/lib/barcode.dart
@@ -1,7 +1,6 @@
 import "dart:io";
 import "package:flutter/material.dart";
 import "package:font_awesome_flutter/font_awesome_flutter.dart";
-import "package:inventree/widget/refreshable_state.dart";
 import "package:one_context/one_context.dart";
 import "package:qr_code_scanner/qr_code_scanner.dart";
 
@@ -11,10 +10,13 @@ import "package:inventree/helpers.dart";
 import "package:inventree/l10.dart";
 import "package:inventree/preferences.dart";
 
+import "package:inventree/inventree/company.dart";
+import "package:inventree/inventree/part.dart";
 import "package:inventree/inventree/sentry.dart";
 import "package:inventree/inventree/stock.dart";
-import "package:inventree/inventree/part.dart";
 
+import "package:inventree/widget/refreshable_state.dart";
+import "package:inventree/widget/supplier_part_detail.dart";
 import "package:inventree/widget/dialogs.dart";
 import "package:inventree/widget/snacks.dart";
 import "package:inventree/widget/location_display.dart";
@@ -183,16 +185,13 @@ class BarcodeScanHandler extends BarcodeHandler {
 
   @override
   Future<void> onBarcodeMatched(Map<String, dynamic> data) async {
-
     int pk = -1;
 
     // A stocklocation has been passed?
     if (data.containsKey("stocklocation")) {
-
       pk = (data["stocklocation"]?["pk"] ?? -1) as int;
 
       if (pk > 0) {
-
         barcodeSuccessTone();
 
         InvenTreeStockLocation().get(pk).then((var loc) {
@@ -203,25 +202,22 @@ class BarcodeScanHandler extends BarcodeHandler {
               icon: Icons.qr_code,
             );
             OneContext().pop();
-            OneContext().navigator.push(MaterialPageRoute(builder: (context) => LocationDisplayWidget(loc)));
+            OneContext().navigator.push(MaterialPageRoute(
+                builder: (context) => LocationDisplayWidget(loc)));
           }
         });
       } else {
-
         barcodeFailureTone();
 
         showSnackIcon(
-          L10().invalidStockLocation,
-          success: false
+            L10().invalidStockLocation,
+            success: false
         );
       }
-
     } else if (data.containsKey("stockitem")) {
-
       pk = (data["stockitem"]?["pk"] ?? -1) as int;
 
       if (pk > 0) {
-
         barcodeSuccessTone();
 
         InvenTreeStockItem().get(pk).then((var item) {
@@ -232,11 +228,11 @@ class BarcodeScanHandler extends BarcodeHandler {
           );
           OneContext().pop();
           if (item is InvenTreeStockItem) {
-            OneContext().push(MaterialPageRoute(builder: (context) => StockDetailWidget(item)));
+            OneContext().push(MaterialPageRoute(
+                builder: (context) => StockDetailWidget(item)));
           }
         });
       } else {
-
         barcodeFailureTone();
 
         showSnackIcon(
@@ -244,12 +240,37 @@ class BarcodeScanHandler extends BarcodeHandler {
             success: false
         );
       }
+    } else if (data.containsKey("supplierpart")) {
+      pk = (data["supplierpart"]?["pk"] ?? -1) as int;
+
+      if (pk > 0) {
+        barcodeSuccessTone();
+
+        InvenTreeSupplierPart().get(pk).then((var supplierpart) {
+          showSnackIcon(
+            L10().supplierPart,
+            success: true,
+            icon: Icons.qr_code,
+          );
+
+          OneContext().pop();
+
+          if (supplierpart is InvenTreeSupplierPart) {
+            OneContext().push(MaterialPageRoute(builder: (context) => SupplierPartDetailWidget(supplierPart)));
+          }
+        });
+      } else {
+        barcodeFailureTone();
+        showSnackIcon(
+          L10().invalidSupplierPart,
+          success: false,
+        );
+      }
     } else if (data.containsKey("part")) {
 
       pk = (data["part"]?["pk"] ?? -1) as int;
 
       if (pk > 0) {
-
         barcodeSuccessTone();
 
         InvenTreePart().get(pk).then((var part) {

--- a/lib/inventree/company.dart
+++ b/lib/inventree/company.dart
@@ -98,6 +98,18 @@ class InvenTreeSupplierPart extends InvenTreeModel {
   @override
   String get URL => "company/part/";
 
+  @override
+  Map<String, dynamic> formFields() {
+    return {
+      "supplier": {},
+      "SKU": {},
+      "link": {},
+      "note": {},
+      "packaging": {},
+      "pack_size": {},
+    };
+  }
+
   Map<String, String> _filters() {
     return {
       "manufacturer_detail": "true",

--- a/lib/inventree/company.dart
+++ b/lib/inventree/company.dart
@@ -140,6 +140,8 @@ class InvenTreeSupplierPart extends InvenTreeModel {
 
   String get partDescription => (jsondata["part_detail"]?["description"] ?? "") as String;
 
+  String get note => (jsondata["note"] ?? "") as String;
+
   @override
   InvenTreeModel createFromJson(Map<String, dynamic> json) {
     var part = InvenTreeSupplierPart.fromJson(json);

--- a/lib/inventree/company.dart
+++ b/lib/inventree/company.dart
@@ -116,9 +116,9 @@ class InvenTreeSupplierPart extends InvenTreeModel {
     return _filters();
   }
 
-  int get manufacturerId => (jsondata["manufacturer"] ?? -1) as int;
-
   String get manufacturerName => (jsondata["manufacturer_detail"]?["name"] ?? "") as String;
+
+  String get MPN => (jsondata["manufacturer_part_detail"]?["MPN"] ?? "") as String;
 
   String get manufacturerImage => (jsondata["manufacturer_detail"]?["image"] ?? jsondata["manufacturer_detail"]["thumbnail"] ?? InvenTreeAPI.staticThumb) as String;
 
@@ -132,13 +132,13 @@ class InvenTreeSupplierPart extends InvenTreeModel {
 
   String get SKU => (jsondata["SKU"] ?? "") as String;
 
-  String get MPN => (jsondata["MPN"] ?? "") as String;
-
   int get partId => (jsondata["part"] ?? -1) as int;
 
   String get partImage => (jsondata["part_detail"]?["thumbnail"] ?? InvenTreeAPI.staticThumb) as String;
 
   String get partName => (jsondata["part_detail"]?["full_name"] ?? "") as String;
+
+  String get partDescription => (jsondata["part_detail"]?["description"] ?? "") as String;
 
   @override
   InvenTreeModel createFromJson(Map<String, dynamic> json) {

--- a/lib/inventree/company.dart
+++ b/lib/inventree/company.dart
@@ -102,7 +102,7 @@ class InvenTreeSupplierPart extends InvenTreeModel {
     return {
       "manufacturer_detail": "true",
       "supplier_detail": "true",
-      "manufacturer_part_detail": "true",
+      "part_detail": "true",
     };
   }
 

--- a/lib/inventree/company.dart
+++ b/lib/inventree/company.dart
@@ -118,17 +118,17 @@ class InvenTreeSupplierPart extends InvenTreeModel {
 
   int get manufacturerId => (jsondata["manufacturer"] ?? -1) as int;
 
-  String get manufacturerName => (jsondata["manufacturer_detail"]["name"] ?? "") as String;
+  String get manufacturerName => (jsondata["manufacturer_detail"]?["name"] ?? "") as String;
 
-  String get manufacturerImage => (jsondata["manufacturer_detail"]["image"] ?? jsondata["manufacturer_detail"]["thumbnail"] ?? InvenTreeAPI.staticThumb) as String;
+  String get manufacturerImage => (jsondata["manufacturer_detail"]?["image"] ?? jsondata["manufacturer_detail"]["thumbnail"] ?? InvenTreeAPI.staticThumb) as String;
 
   int get manufacturerPartId => (jsondata["manufacturer_part"] ?? -1) as int;
 
   int get supplierId => (jsondata["supplier"] ?? -1) as int;
 
-  String get supplierName => (jsondata["supplier_detail"]["name"] ?? "") as String;
+  String get supplierName => (jsondata["supplier_detail"]?["name"] ?? "") as String;
 
-  String get supplierImage => (jsondata["supplier_detail"]["image"] ?? jsondata["supplier_detail"]["thumbnail"] ?? InvenTreeAPI.staticThumb) as String;
+  String get supplierImage => (jsondata["supplier_detail"]?["image"] ?? jsondata["supplier_detail"]["thumbnail"] ?? InvenTreeAPI.staticThumb) as String;
 
   String get SKU => (jsondata["SKU"] ?? "") as String;
 
@@ -136,9 +136,9 @@ class InvenTreeSupplierPart extends InvenTreeModel {
 
   int get partId => (jsondata["part"] ?? -1) as int;
 
-  String get partImage => (jsondata["part_detail"]["thumbnail"] ?? InvenTreeAPI.staticThumb) as String;
+  String get partImage => (jsondata["part_detail"]?["thumbnail"] ?? InvenTreeAPI.staticThumb) as String;
 
-  String get partName => (jsondata["part_detail"]["full_name"] ?? "") as String;
+  String get partName => (jsondata["part_detail"]?["full_name"] ?? "") as String;
 
   @override
   InvenTreeModel createFromJson(Map<String, dynamic> json) {

--- a/lib/inventree/stock.dart
+++ b/lib/inventree/stock.dart
@@ -416,8 +416,10 @@ class InvenTreeStockItem extends InvenTreeModel {
   String get supplierImage {
     String thumb = "";
 
-    if (jsondata.containsKey("supplier_detail")) {
-      thumb = (jsondata["supplier_detail"]["supplier_logo"] ?? "") as String;
+    if (jsondata.containsKey("supplier_part_detail")) {
+      thumb = (jsondata["supplier_part_detail"]?["supplier_detail"]?["image"] ?? "") as String;
+    } else if (jsondata.containsKey("supplier_detail")) {
+      thumb = (jsondata["supplier_detail"]["image"] ?? "") as String;
     }
 
     return thumb;
@@ -440,8 +442,8 @@ class InvenTreeStockItem extends InvenTreeModel {
   String get supplierSKU {
     String sku = "";
 
-    if (jsondata.containsKey("supplier_detail")) {
-      sku = (jsondata["supplier_detail"]["SKU"] ?? "") as String;
+    if (jsondata.containsKey("supplier_part_detail")) {
+      sku = (jsondata["supplier_part_detail"]["SKU"] ?? "") as String;
     }
 
     return sku;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1107,6 +1107,12 @@
   "supplier": "Supplier",
   "@supplier": {},
 
+  "supplierPart": "Supplier Part",
+  "@supplierPart": {},
+
+  "supplierParts": "Supplier Parts",
+  "@supplierParts": {},
+
   "suppliers": "Suppliers",
   "@suppliers": {},
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -467,6 +467,9 @@
   "invalidStockItem": "Invalid Stock Item",
   "@invalidStockItem": {},
 
+  "invalidSupplierPart": "Invalid Supplier Part",
+  "@invalidSupplierPart": {},
+
   "invalidUsernamePassword": "Invalid username / password combination",
   "@invalidUsernamePassword": {},
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1110,6 +1110,12 @@
   "supplierPart": "Supplier Part",
   "@supplierPart": {},
 
+  "supplierPartEdit": "Edit Supplier Part",
+  "@supplierPartEdit": {},
+
+  "supplierPartUpdated": "Supplier Part Updated",
+  "@supplierPartUpdated": {},
+
   "supplierParts": "Supplier Parts",
   "@supplierParts": {},
 

--- a/lib/settings/home_settings.dart
+++ b/lib/settings/home_settings.dart
@@ -85,9 +85,6 @@ class _HomeScreenSettingsState extends State<HomeScreenSettingsWidget> {
                       },
                     ),
                   ),
-                  // TODO: When these features are improved, add them back in!
-                  // Currently, the company display does not provide any value
-                  /*
                   ListTile(
                     title: Text(L10().homeShowSuppliers),
                     subtitle: Text(L10().homeShowSuppliersDescription),
@@ -102,6 +99,9 @@ class _HomeScreenSettingsState extends State<HomeScreenSettingsWidget> {
                       },
                     ),
                   ),
+                  // TODO: When these features are improved, add them back in!
+                  // Currently, the company display does not provide any value
+                  /*
                   ListTile(
                     title: Text(L10().homeShowManufacturers),
                     subtitle: Text(L10().homeShowManufacturersDescription),

--- a/lib/widget/attachment_widget.dart
+++ b/lib/widget/attachment_widget.dart
@@ -6,13 +6,16 @@ import "package:font_awesome_flutter/font_awesome_flutter.dart";
 import "package:one_context/one_context.dart";
 import "package:url_launcher/url_launcher.dart";
 
+import "package:inventree/l10.dart";
 import "package:inventree/app_colors.dart";
+
 import "package:inventree/inventree/model.dart";
+
 import "package:inventree/widget/fields.dart";
 import "package:inventree/widget/progress.dart";
 import "package:inventree/widget/snacks.dart";
 import "package:inventree/widget/refreshable_state.dart";
-import "package:inventree/l10.dart";
+
 
 /*
  * A generic widget for displaying a list of attachments.

--- a/lib/widget/bom_list.dart
+++ b/lib/widget/bom_list.dart
@@ -4,9 +4,9 @@ import "package:font_awesome_flutter/font_awesome_flutter.dart";
 
 import "package:inventree/api.dart";
 import "package:inventree/helpers.dart";
-import "package:inventree/inventree/bom.dart";
 import "package:inventree/l10.dart";
 
+import "package:inventree/inventree/bom.dart";
 import "package:inventree/inventree/model.dart";
 import "package:inventree/inventree/part.dart";
 

--- a/lib/widget/category_display.dart
+++ b/lib/widget/category_display.dart
@@ -22,13 +22,13 @@ class CategoryDisplayWidget extends StatefulWidget {
   final InvenTreePartCategory? category;
 
   @override
-  _CategoryDisplayState createState() => _CategoryDisplayState(category);
+  _CategoryDisplayState createState() => _CategoryDisplayState();
 }
 
 
 class _CategoryDisplayState extends RefreshableState<CategoryDisplayWidget> {
 
-  _CategoryDisplayState(this.category);
+  _CategoryDisplayState();
 
   bool showFilterOptions = false;
 
@@ -40,7 +40,7 @@ class _CategoryDisplayState extends RefreshableState<CategoryDisplayWidget> {
 
     List<Widget> actions = [];
 
-    if ((category != null) && InvenTreeAPI().checkPermission("part_category", "change")) {
+    if ((widget.category != null) && InvenTreeAPI().checkPermission("part_category", "change")) {
       actions.add(
         IconButton(
           icon: FaIcon(FontAwesomeIcons.edit),
@@ -57,7 +57,7 @@ class _CategoryDisplayState extends RefreshableState<CategoryDisplayWidget> {
   }
 
   void _editCategoryDialog(BuildContext context) {
-    final _cat = category;
+    final _cat = widget.category;
 
     // Cannot edit top-level category
     if (_cat == null) {
@@ -74,9 +74,6 @@ class _CategoryDisplayState extends RefreshableState<CategoryDisplayWidget> {
     );
   }
 
-  // The local InvenTreePartCategory object
-  final InvenTreePartCategory? category;
-
   @override
   Future<void> onBuild(BuildContext context) async {
     refresh(context);
@@ -86,8 +83,8 @@ class _CategoryDisplayState extends RefreshableState<CategoryDisplayWidget> {
   Future<void> request(BuildContext context) async {
 
     // Update the category
-    if (category != null) {
-      final bool result = await category?.reload() ?? false;
+    if (widget.category != null) {
+      final bool result = await widget.category?.reload() ?? false;
 
       if (!result) {
         Navigator.of(context).pop();
@@ -96,7 +93,7 @@ class _CategoryDisplayState extends RefreshableState<CategoryDisplayWidget> {
   }
 
   Widget getCategoryDescriptionCard({bool extra = true}) {
-    if (category == null) {
+    if (widget.category == null) {
       return Card(
         child: ListTile(
           leading: FaIcon(FontAwesomeIcons.shapes),
@@ -110,11 +107,11 @@ class _CategoryDisplayState extends RefreshableState<CategoryDisplayWidget> {
 
       List<Widget> children = [
         ListTile(
-          title: Text("${category?.name}",
+          title: Text("${widget.category?.name}",
               style: TextStyle(fontWeight: FontWeight.bold)
           ),
-          subtitle: Text("${category?.description}"),
-          leading: category!.customIcon ?? FaIcon(FontAwesomeIcons.sitemap),
+          subtitle: Text("${widget.category?.description}"),
+          leading: widget.category!.customIcon ?? FaIcon(FontAwesomeIcons.sitemap),
         ),
       ];
 
@@ -122,14 +119,14 @@ class _CategoryDisplayState extends RefreshableState<CategoryDisplayWidget> {
         children.add(
             ListTile(
               title: Text(L10().parentCategory),
-              subtitle: Text("${category?.parentPathString}"),
+              subtitle: Text("${widget.category?.parentPathString}"),
               leading: FaIcon(
                 FontAwesomeIcons.levelUpAlt,
                 color: COLOR_CLICK,
               ),
               onTap: () async {
 
-                int parentId = category?.parentId ?? -1;
+                int parentId = widget.category?.parentId ?? -1;
 
                 if (parentId < 0) {
                   Navigator.push(context, MaterialPageRoute(builder: (context) => CategoryDisplayWidget(null)));
@@ -200,7 +197,7 @@ class _CategoryDisplayState extends RefreshableState<CategoryDisplayWidget> {
       Expanded(
         child: PaginatedPartCategoryList(
             {
-              "parent": category?.pk.toString() ?? "null"
+              "parent": widget.category?.pk.toString() ?? "null"
             },
             showFilterOptions,
         ),
@@ -215,7 +212,7 @@ class _CategoryDisplayState extends RefreshableState<CategoryDisplayWidget> {
   List<Widget> partsTiles() {
 
     Map<String, String> filters = {
-      "category": category?.pk.toString() ?? "null",
+      "category": widget.category?.pk.toString() ?? "null",
     };
 
     return [
@@ -246,7 +243,7 @@ class _CategoryDisplayState extends RefreshableState<CategoryDisplayWidget> {
 
   Future<void> _newCategory(BuildContext context) async {
 
-    int pk = category?.pk ?? -1;
+    int pk = widget.category?.pk ?? -1;
 
     InvenTreePartCategory().createForm(
       context,
@@ -276,7 +273,7 @@ class _CategoryDisplayState extends RefreshableState<CategoryDisplayWidget> {
 
   Future<void> _newPart() async {
 
-    int pk = category?.pk ?? -1;
+    int pk = widget.category?.pk ?? -1;
 
     InvenTreePart().createForm(
       context,
@@ -320,7 +317,7 @@ class _CategoryDisplayState extends RefreshableState<CategoryDisplayWidget> {
           )
       );
 
-      if (category != null) {
+      if (widget.category != null) {
         tiles.add(
             ListTile(
               title: Text(L10().partCreate),

--- a/lib/widget/category_list.dart
+++ b/lib/widget/category_list.dart
@@ -17,16 +17,14 @@ class PartCategoryList extends StatefulWidget {
   final Map<String, String> filters;
 
   @override
-  _PartCategoryListState createState() => _PartCategoryListState(filters);
+  _PartCategoryListState createState() => _PartCategoryListState();
 
 }
 
 
 class _PartCategoryListState extends RefreshableState<PartCategoryList> {
 
-  _PartCategoryListState(this.filters);
-
-  final Map<String, String> filters;
+  _PartCategoryListState();
 
   bool showFilterOptions = false;
 
@@ -47,7 +45,7 @@ class _PartCategoryListState extends RefreshableState<PartCategoryList> {
 
   @override
   Widget getBody(BuildContext context) {
-    return PaginatedPartCategoryList(filters, showFilterOptions);
+    return PaginatedPartCategoryList(widget.filters, showFilterOptions);
   }
 }
 

--- a/lib/widget/company_detail.dart
+++ b/lib/widget/company_detail.dart
@@ -14,6 +14,9 @@ import "package:inventree/widget/snacks.dart";
 import "package:inventree/widget/supplier_part_list.dart";
 
 
+/*
+ * Widget for displaying detail view of a single Company instance
+ */
 class CompanyDetailWidget extends StatefulWidget {
 
   const CompanyDetailWidget(this.company, {Key? key}) : super(key: key);

--- a/lib/widget/company_list.dart
+++ b/lib/widget/company_list.dart
@@ -2,13 +2,18 @@
 import "package:flutter/material.dart";
 
 import "package:inventree/api.dart";
+
 import "package:inventree/inventree/company.dart";
 import "package:inventree/inventree/model.dart";
+
 import "package:inventree/widget/paginator.dart";
 import "package:inventree/widget/refreshable_state.dart";
 import "package:inventree/widget/company_detail.dart";
 
 
+/*
+ * Widget for displaying a filterable list of Company instances
+ */
 class CompanyListWidget extends StatefulWidget {
 
   const CompanyListWidget(this.title, this.filters, {Key? key}) : super(key: key);
@@ -18,24 +23,20 @@ class CompanyListWidget extends StatefulWidget {
   final Map<String, String> filters;
 
   @override
-  _CompanyListWidgetState createState() => _CompanyListWidgetState(title, filters);
+  _CompanyListWidgetState createState() => _CompanyListWidgetState();
 }
 
 
 class _CompanyListWidgetState extends RefreshableState<CompanyListWidget> {
 
-  _CompanyListWidgetState(this.title, this.filters);
-
-  final String title;
-
-  final Map<String, String> filters;
+  _CompanyListWidgetState();
 
   @override
-  String getAppBarTitle(BuildContext context) => title;
+  String getAppBarTitle(BuildContext context) => widget.title;
 
   @override
   Widget getBody(BuildContext context) {
-    return PaginatedCompanyList(filters, true);
+    return PaginatedCompanyList(widget.filters, true);
   }
 
 }

--- a/lib/widget/dialogs.dart
+++ b/lib/widget/dialogs.dart
@@ -1,10 +1,11 @@
 import "package:flutter/material.dart";
 import "package:font_awesome_flutter/font_awesome_flutter.dart";
-import "package:inventree/helpers.dart";
 import "package:one_context/one_context.dart";
 
 import "package:inventree/api.dart";
+import "package:inventree/helpers.dart";
 import "package:inventree/l10.dart";
+
 import "package:inventree/preferences.dart";
 import "package:inventree/widget/snacks.dart";
 

--- a/lib/widget/drawer.dart
+++ b/lib/widget/drawer.dart
@@ -1,14 +1,24 @@
-import "package:inventree/api.dart";
-import "package:inventree/barcode.dart";
 import "package:flutter/material.dart";
-import "package:inventree/l10.dart";
-import "package:inventree/settings/about.dart";
-
-import "package:inventree/settings/settings.dart";
 import "package:font_awesome_flutter/font_awesome_flutter.dart";
-import "package:inventree/widget/search.dart";
 import "package:package_info_plus/package_info_plus.dart";
 
+import "package:inventree/api.dart";
+import "package:inventree/barcode.dart";
+import "package:inventree/l10.dart";
+
+import "package:inventree/settings/about.dart";
+import "package:inventree/settings/settings.dart";
+
+import "package:inventree/widget/search.dart";
+
+
+/*
+ * Custom "drawer" widget for the InvenTree app.
+ *
+ * - Provides a "home" button which completely unwinds the widget stack
+ * - Global search
+ * - Barcoed scan
+ */
 class InvenTreeDrawer extends StatelessWidget {
 
   const InvenTreeDrawer(this.context);

--- a/lib/widget/home.dart
+++ b/lib/widget/home.dart
@@ -301,7 +301,7 @@ class _InvenTreeHomePageState extends State<InvenTreeHomePage> {
         }
     ));
 
-    // Purchase orderes
+    // Purchase orders
     if (homeShowPo) {
       tiles.add(_listTile(
           context,

--- a/lib/widget/home.dart
+++ b/lib/widget/home.dart
@@ -24,6 +24,7 @@ import "package:inventree/widget/purchase_order_list.dart";
 import "package:inventree/widget/search.dart";
 import "package:inventree/widget/snacks.dart";
 import "package:inventree/widget/spinner.dart";
+import "package:inventree/widget/company_list.dart";
 
 
 class InvenTreeHomePage extends StatefulWidget {
@@ -126,13 +127,13 @@ class _InvenTreeHomePageState extends State<InvenTreeHomePage> {
     );
   }
 
-  /*
   void _showSuppliers(BuildContext context) {
     if (!InvenTreeAPI().checkConnection()) return;
 
     Navigator.push(context, MaterialPageRoute(builder: (context) => CompanyListWidget(L10().suppliers, {"is_supplier": "true"})));
   }
 
+  /*
   void _showManufacturers(BuildContext context) {
     if (!InvenTreeAPI().checkConnection()) return;
 
@@ -312,8 +313,6 @@ class _InvenTreeHomePageState extends State<InvenTreeHomePage> {
       ));
     }
 
-    // TODO: Add these tiles back in once the features are fleshed out
-    /*
     // Suppliers
     if (homeShowSuppliers) {
       tiles.add(_listTile(
@@ -325,6 +324,10 @@ class _InvenTreeHomePageState extends State<InvenTreeHomePage> {
           }
       ));
     }
+
+    // TODO: Add these tiles back in once the features are fleshed out
+    /*
+
 
     // Manufacturers
     if (homeShowManufacturers) {

--- a/lib/widget/part_detail.dart
+++ b/lib/widget/part_detail.dart
@@ -25,6 +25,7 @@ import "package:inventree/widget/part_image_widget.dart";
 import "package:inventree/widget/snacks.dart";
 import "package:inventree/widget/stock_detail.dart";
 import "package:inventree/widget/stock_list.dart";
+import "package:inventree/widget/supplier_part_list.dart";
 
 
 /*
@@ -523,21 +524,24 @@ class _PartDisplayState extends RefreshableState<PartDetailWidget> {
     }
 
     if (part.isPurchaseable) {
-      tiles.add(
-          ListTile(
-            title: Text(L10().suppliers),
-            leading: FaIcon(FontAwesomeIcons.industry),
-            trailing: Text("${part.supplierCount}"),
-            /* TODO:
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (context) => PartSupplierWidget(part))
-                );
-              },
-               */
-          )
-      );
+
+      if (part.supplierCount > 0) {
+        tiles.add(
+            ListTile(
+              title: Text(L10().suppliers),
+              leading: FaIcon(FontAwesomeIcons.industry, color: COLOR_CLICK),
+              trailing: Text("${part.supplierCount}"),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => SupplierPartList({
+                      "part": part.pk.toString()
+                    }))
+                  );
+                },
+            )
+        );
+      }
     }
 
     if (showParameters) {

--- a/lib/widget/part_detail.dart
+++ b/lib/widget/part_detail.dart
@@ -117,6 +117,7 @@ class _PartDisplayState extends RefreshableState<PartDetailWidget> {
     if (!result || part.pk == -1) {
       // Part could not be loaded, for some reason
       Navigator.of(context).pop();
+      return;
     }
 
     // If the part points to a parent "template" part, request that too

--- a/lib/widget/part_list.dart
+++ b/lib/widget/part_list.dart
@@ -120,12 +120,9 @@ class _PaginatedPartListState extends PaginatedSearchState<PaginatedPartList> {
 
   @override
   Future<InvenTreePageResponse?> requestPage(int limit, int offset, Map<String, String> params) async {
-
     final page = await InvenTreePart().listPaginated(limit, offset, filters: params);
-
     return page;
   }
-
 
   @override
   Widget buildItem(BuildContext context, InvenTreeModel model) {

--- a/lib/widget/stock_detail.dart
+++ b/lib/widget/stock_detail.dart
@@ -551,6 +551,22 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
       );
     }
 
+    // Supplier part information (if available)
+    if (widget.item.supplierPartId > 0) {
+      tiles.add(
+        ListTile(
+          title: Text(L10().supplierPart),
+          subtitle: Text(widget.item.supplierSKU),
+          leading: FaIcon(FontAwesomeIcons.building, color: COLOR_CLICK),
+          trailing: InvenTreeAPI().getImage(
+            widget.item.supplierImage,
+            width: 40,
+            height: 40,
+          ),
+        )
+      );
+    }
+
     if (widget.item.isBuilding) {
       tiles.add(
         ListTile(
@@ -606,22 +622,6 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
         )
       );
     }
-
-    // Supplier part?
-    // TODO: Display supplier part info page?
-    /*
-    if (item.supplierPartId > 0) {
-      tiles.add(
-        ListTile(
-          title: Text("${item.supplierName}"),
-          subtitle: Text("${item.supplierSKU}"),
-          leading: FaIcon(FontAwesomeIcons.industry),
-          trailing: InvenTreeAPI().getImage(item.supplierImage),
-          onTap: null,
-        )
-      );
-    }
-     */
 
     if (widget.item.link.isNotEmpty) {
       tiles.add(

--- a/lib/widget/stock_detail.dart
+++ b/lib/widget/stock_detail.dart
@@ -4,8 +4,16 @@ import "package:font_awesome_flutter/font_awesome_flutter.dart";
 
 import "package:inventree/app_colors.dart";
 import "package:inventree/barcode.dart";
+import "package:inventree/l10.dart";
+import "package:inventree/api.dart";
+import "package:inventree/api_form.dart";
+import "package:inventree/preferences.dart";
+
+import "package:inventree/inventree/company.dart";
 import "package:inventree/inventree/stock.dart";
 import "package:inventree/inventree/part.dart";
+
+import "package:inventree/widget/supplier_part_detail.dart";
 import "package:inventree/widget/dialogs.dart";
 import "package:inventree/widget/attachment_widget.dart";
 import "package:inventree/widget/location_display.dart";
@@ -16,10 +24,6 @@ import "package:inventree/widget/snacks.dart";
 import "package:inventree/widget/stock_item_history.dart";
 import "package:inventree/widget/stock_item_test_results.dart";
 import "package:inventree/widget/stock_notes.dart";
-import "package:inventree/l10.dart";
-import "package:inventree/api.dart";
-import "package:inventree/api_form.dart";
-import "package:inventree/preferences.dart";
 
 
 class StockDetailWidget extends StatefulWidget {
@@ -563,6 +567,18 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
             width: 40,
             height: 40,
           ),
+          onTap: () async {
+            showLoadingOverlay(context);
+            var sp = await InvenTreeSupplierPart().get(
+                widget.item.supplierPartId);
+            hideLoadingOverlay();
+            if (sp is InvenTreeSupplierPart) {
+              Navigator.push(
+                  context, MaterialPageRoute(
+                  builder: (context) => SupplierPartDetailWidget(sp))
+              );
+            }
+          }
         )
       );
     }

--- a/lib/widget/stock_detail.dart
+++ b/lib/widget/stock_detail.dart
@@ -29,13 +29,13 @@ class StockDetailWidget extends StatefulWidget {
   final InvenTreeStockItem item;
 
   @override
-  _StockItemDisplayState createState() => _StockItemDisplayState(item);
+  _StockItemDisplayState createState() => _StockItemDisplayState();
 }
 
 
 class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
 
-  _StockItemDisplayState(this.item);
+  _StockItemDisplayState();
 
   @override
   String getAppBarTitle(BuildContext context) => L10().stockItem;
@@ -62,7 +62,7 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
           icon: FaIcon(FontAwesomeIcons.searchLocation),
           tooltip: L10().locateItem,
           onPressed: () async {
-            InvenTreeAPI().locateItemOrLocation(context, item: item.pk);
+            InvenTreeAPI().locateItemOrLocation(context, item: widget.item.pk);
           },
         )
       );
@@ -82,11 +82,8 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
   }
 
   Future<void> _openInvenTreePage() async {
-    item.goToInvenTreePage();
+    widget.item.goToInvenTreePage();
   }
-
-  // StockItem object
-  final InvenTreeStockItem item;
 
   // Is label printing enabled for this StockItem?
   // This will be determined when the widget is loaded
@@ -111,7 +108,7 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
 
     stockShowHistory = await InvenTreeSettingsManager().getValue(INV_STOCK_SHOW_HISTORY, false) as bool;
 
-    final bool result = item.pk > 0 && await item.reload();
+    final bool result = widget.item.pk > 0 && await widget.item.reload();
 
     // Could not load this stock item for some reason
     // Perhaps it has been depleted?
@@ -120,10 +117,10 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
     }
 
     // Request part information
-    part = await InvenTreePart().get(item.partId) as InvenTreePart?;
+    part = await InvenTreePart().get(widget.item.partId) as InvenTreePart?;
 
     // Request test results (async)
-    item.getTestResults().then((value) {
+    widget.item.getTestResults().then((value) {
 
       if (mounted) {
         setState(() {
@@ -135,7 +132,7 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
     // Request the number of attachments
     InvenTreeStockItemAttachment().count(
       filters: {
-        "stock_item": item.pk.toString()
+        "stock_item": widget.item.pk.toString()
       }
     ).then((int value) {
 
@@ -165,7 +162,7 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
         "/label/stock/",
         params: {
           "enabled": "true",
-          "item": "${item.pk}",
+          "item": "${widget.item.pk}",
         },
     ).then((APIResponse response) {
       if (response.isValid() && response.statusCode == 200) {
@@ -190,7 +187,7 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
       L10().stockItemDeleteConfirm,
       icon: FontAwesomeIcons.trashAlt,
       onAccept: () async {
-        final bool result = await item.delete();
+        final bool result = await widget.item.delete();
         
         if (result) {
           Navigator.of(context).pop();
@@ -264,7 +261,7 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
         String pluginKey = (data["plugin"] ?? "") as String;
 
         if (labelId != -1 && pluginKey.isNotEmpty) {
-          String url = "/label/stock/${labelId}/print/?item=${item.pk}&plugin=${pluginKey}";
+          String url = "/label/stock/${labelId}/print/?item=${widget.item.pk}&plugin=${pluginKey}";
 
           InvenTreeAPI().get(url).then((APIResponse response) {
             if (response.isValid() && response.statusCode == 200) {
@@ -298,7 +295,7 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
       fields.remove("serial");
     }
 
-    item.editForm(
+    widget.item.editForm(
       context,
       L10().editItem,
       fields: fields,
@@ -320,7 +317,7 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
         "parent": "items",
         "nested": true,
         "hidden": true,
-        "value": item.pk,
+        "value": widget.item.pk,
       },
       "quantity": {
         "parent": "items",
@@ -361,7 +358,7 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
         "parent": "items",
         "nested": true,
         "hidden": true,
-        "value": item.pk,
+        "value": widget.item.pk,
       },
       "quantity": {
         "parent": "items",
@@ -392,12 +389,12 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
         "parent": "items",
         "nested": true,
         "hidden": true,
-        "value": item.pk,
+        "value": widget.item.pk,
       },
       "quantity": {
         "parent": "items",
         "nested": true,
-        "value": item.quantity,
+        "value": widget.item.quantity,
       },
       "notes": {},
     };
@@ -426,18 +423,18 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
         "parent": "items",
         "nested": true,
         "hidden": true,
-        "value": item.pk,
+        "value": widget.item.pk,
       },
       "quantity": {
         "parent": "items",
         "nested": true,
-        "value": item.quantity,
+        "value": widget.item.quantity,
       },
       "location": {},
       "notes": {},
     };
 
-    if (item.isSerialized()) {
+    if (widget.item.isSerialized()) {
       // Prevent editing of 'quantity' field if the item is serialized
       fields["quantity"]["hidden"] = true;
     }
@@ -459,20 +456,20 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
   Widget headerTile() {
     return Card(
       child: ListTile(
-        title: Text("${item.partName}"),
-        subtitle: Text("${item.partDescription}"),
-        leading: InvenTreeAPI().getImage(item.partImage),
+        title: Text("${widget.item.partName}"),
+        subtitle: Text("${widget.item.partDescription}"),
+        leading: InvenTreeAPI().getImage(widget.item.partImage),
         trailing: Text(
-          item.statusLabel(),
+            widget.item.statusLabel(),
           style: TextStyle(
-            color: item.statusColor
+            color: widget.item.statusColor
           )
         ),
         onTap: () async {
-          if (item.partId > 0) {
+          if (widget.item.partId > 0) {
 
             showLoadingOverlay(context);
-            var part = await InvenTreePart().get(item.partId);
+            var part = await InvenTreePart().get(widget.item.partId);
             hideLoadingOverlay();
 
             if (part is InvenTreePart) {
@@ -501,39 +498,39 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
     }
 
     // Quantity information
-    if (item.isSerialized()) {
+    if (widget.item.isSerialized()) {
       tiles.add(
           ListTile(
             title: Text(L10().serialNumber),
             leading: FaIcon(FontAwesomeIcons.hashtag),
-            trailing: Text("${item.serialNumber}"),
+            trailing: Text("${widget.item.serialNumber}"),
           )
       );
     } else {
       tiles.add(
           ListTile(
-            title: item.allocated > 0 ? Text(L10().quantityAvailable) : Text(L10().quantity),
+            title: widget.item.allocated > 0 ? Text(L10().quantityAvailable) : Text(L10().quantity),
             leading: FaIcon(FontAwesomeIcons.cubes),
-            trailing: Text("${item.quantityString()}"),
+            trailing: Text("${widget.item.quantityString()}"),
           )
       );
     }
 
     // Location information
-    if ((item.locationId > 0) && (item.locationName.isNotEmpty)) {
+    if ((widget.item.locationId > 0) && (widget.item.locationName.isNotEmpty)) {
       tiles.add(
           ListTile(
             title: Text(L10().stockLocation),
-            subtitle: Text("${item.locationPathString}"),
+            subtitle: Text("${widget.item.locationPathString}"),
             leading: FaIcon(
               FontAwesomeIcons.mapMarkerAlt,
               color: COLOR_CLICK,
             ),
             onTap: () async {
-              if (item.locationId > 0) {
+              if (widget.item.locationId > 0) {
 
                 showLoadingOverlay(context);
-                var loc = await InvenTreeStockLocation().get(item.locationId);
+                var loc = await InvenTreeStockLocation().get(widget.item.locationId);
                 hideLoadingOverlay();
 
                 if (loc is InvenTreeStockLocation) {
@@ -554,7 +551,7 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
       );
     }
 
-    if (item.isBuilding) {
+    if (widget.item.isBuilding) {
       tiles.add(
         ListTile(
           title: Text(L10().inProduction),
@@ -567,44 +564,44 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
       );
     }
 
-    if (item.batch.isNotEmpty) {
+    if (widget.item.batch.isNotEmpty) {
       tiles.add(
         ListTile(
           title: Text(L10().batchCode),
-          subtitle: Text(item.batch),
+          subtitle: Text(widget.item.batch),
           leading: FaIcon(FontAwesomeIcons.layerGroup),
         )
       );
     }
 
-    if (item.packaging.isNotEmpty) {
+    if (widget.item.packaging.isNotEmpty) {
       tiles.add(
         ListTile(
           title: Text(L10().packaging),
-          subtitle: Text(item.packaging),
+          subtitle: Text(widget.item.packaging),
           leading: FaIcon(FontAwesomeIcons.box),
         )
       );
     }
 
     // Last update?
-    if (item.updatedDateString.isNotEmpty) {
+    if (widget.item.updatedDateString.isNotEmpty) {
 
       tiles.add(
         ListTile(
           title: Text(L10().lastUpdated),
-          subtitle: Text(item.updatedDateString),
+          subtitle: Text(widget.item.updatedDateString),
           leading: FaIcon(FontAwesomeIcons.calendarAlt)
         )
       );
     }
 
     // Stocktake?
-    if (item.stocktakeDateString.isNotEmpty) {
+    if (widget.item.stocktakeDateString.isNotEmpty) {
       tiles.add(
         ListTile(
           title: Text(L10().lastStocktake),
-          subtitle: Text(item.stocktakeDateString),
+          subtitle: Text(widget.item.stocktakeDateString),
           leading: FaIcon(FontAwesomeIcons.calendarAlt)
         )
       );
@@ -626,29 +623,29 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
     }
      */
 
-    if (item.link.isNotEmpty) {
+    if (widget.item.link.isNotEmpty) {
       tiles.add(
         ListTile(
-          title: Text("${item.link}"),
+          title: Text("${widget.item.link}"),
           leading: FaIcon(FontAwesomeIcons.link, color: COLOR_CLICK),
           onTap: () {
-            item.openLink();
+            widget.item.openLink();
           },
         )
       );
     }
 
-    if ((item.testResultCount > 0) || (part?.isTrackable ?? false)) {
+    if ((widget.item.testResultCount > 0) || (part?.isTrackable ?? false)) {
       tiles.add(
           ListTile(
               title: Text(L10().testResults),
               leading: FaIcon(FontAwesomeIcons.tasks, color: COLOR_CLICK),
-              trailing: Text("${item.testResultCount}"),
+              trailing: Text("${widget.item.testResultCount}"),
               onTap: () {
                 Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (context) => StockItemTestResultsWidget(item))
+                        builder: (context) => StockItemTestResultsWidget(widget.item))
                 ).then((ctx) {
                   refresh(context);
                 });
@@ -657,29 +654,29 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
       );
     }
 
-    if (item.hasPurchasePrice) {
+    if (widget.item.hasPurchasePrice) {
       tiles.add(
         ListTile(
           title: Text(L10().purchasePrice),
           leading: FaIcon(FontAwesomeIcons.dollarSign),
-          trailing: Text(item.purchasePrice),
+          trailing: Text(widget.item.purchasePrice),
         )
       );
     }
 
     // TODO - Is this stock item linked to a PurchaseOrder?
 
-    if (stockShowHistory && item.trackingItemCount > 0) {
+    if (stockShowHistory && widget.item.trackingItemCount > 0) {
       tiles.add(
         ListTile(
           title: Text(L10().history),
           leading: FaIcon(FontAwesomeIcons.history, color: COLOR_CLICK),
-          trailing: Text("${item.trackingItemCount}"),
+          trailing: Text("${widget.item.trackingItemCount}"),
           onTap: () {
             Navigator.push(
               context,
               MaterialPageRoute(
-                builder: (context) => StockItemHistoryWidget(item))
+                builder: (context) => StockItemHistoryWidget(widget.item))
               ).then((ctx) {
                 refresh(context);
             });
@@ -696,7 +693,7 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
         onTap: () {
           Navigator.push(
             context,
-            MaterialPageRoute(builder: (context) => StockNotesWidget(item))
+            MaterialPageRoute(builder: (context) => StockNotesWidget(widget.item))
           );
         }
       )
@@ -713,7 +710,7 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
                 MaterialPageRoute(
                     builder: (context) => AttachmentWidget(
                         InvenTreeStockItemAttachment(),
-                        item.pk,
+                        widget.item.pk,
                         InvenTreeAPI().checkPermission("stock", "change"))
                 )
             );
@@ -748,13 +745,13 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
     }
 
     // "Count" is not available for serialized stock
-    if (!item.isSerialized()) {
+    if (!widget.item.isSerialized()) {
       tiles.add(
           ListTile(
               title: Text(L10().countStock),
               leading: FaIcon(FontAwesomeIcons.checkCircle, color: COLOR_CLICK),
               onTap: _countStockDialog,
-              trailing: Text(item.quantityString(includeUnits: true)),
+              trailing: Text(widget.item.quantityString(includeUnits: true)),
           )
       );
 
@@ -794,7 +791,7 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
         onTap: () {
           Navigator.push(
             context,
-            MaterialPageRoute(builder: (context) => InvenTreeQRView(StockItemScanIntoLocationHandler(item)))
+            MaterialPageRoute(builder: (context) => InvenTreeQRView(StockItemScanIntoLocationHandler(widget.item)))
           ).then((ctx) {
             refresh(context);
           });
@@ -802,8 +799,8 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
       )
     );
 
-    if (InvenTreeAPI().supportModernBarcodes || item.customBarcode.isEmpty) {
-      tiles.add(customBarcodeActionTile(context, this, item.customBarcode, "stockitem", item.pk));
+    if (InvenTreeAPI().supportModernBarcodes || widget.item.customBarcode.isEmpty) {
+      tiles.add(customBarcodeActionTile(context, this, widget.item.customBarcode, "stockitem", widget.item.pk));
     } else {
       // Note: Custom legacy barcodes (only for StockItem model) are handled differently
       tiles.add(
@@ -811,7 +808,7 @@ class _StockItemDisplayState extends RefreshableState<StockDetailWidget> {
               title: Text(L10().barcodeUnassign),
               leading: Icon(Icons.qr_code, color: COLOR_CLICK),
               onTap: () async {
-                await item.update(values: {"uid": ""});
+                await widget.item.update(values: {"uid": ""});
                 refresh(context);
               }
           )

--- a/lib/widget/supplier_part_detail.dart
+++ b/lib/widget/supplier_part_detail.dart
@@ -111,7 +111,7 @@ class _SupplierPartDisplayState extends RefreshableState<SupplierPartDetailWidge
         )
     );
 
-    // Supplier part details
+    // Supplier details
     tiles.add(
       ListTile(
         title: Text(widget.supplierPart.SKU),

--- a/lib/widget/supplier_part_detail.dart
+++ b/lib/widget/supplier_part_detail.dart
@@ -7,6 +7,7 @@ import "package:inventree/l10.dart";
 import "package:inventree/inventree/part.dart";
 import "package:inventree/inventree/company.dart";
 
+import "package:inventree/widget/company_detail.dart";
 import "package:inventree/widget/part_detail.dart";
 import "package:inventree/widget/progress.dart";
 import "package:inventree/widget/refreshable_state.dart";
@@ -87,6 +88,17 @@ class _SupplierPartDisplayState extends RefreshableState<SupplierPartDetailWidge
           width: 40,
           height: 40,
         ),
+        onTap: () async {
+          showLoadingOverlay(context);
+          var supplier = await InvenTreeCompany().get(widget.supplierPart.supplierId);
+          hideLoadingOverlay();
+
+          if (supplier is InvenTreeCompany) {
+            Navigator.push(context, MaterialPageRoute(
+              builder: (context) => CompanyDetailWidget(supplier)
+            ));
+          }
+        }
       )
     );
 

--- a/lib/widget/supplier_part_detail.dart
+++ b/lib/widget/supplier_part_detail.dart
@@ -11,6 +11,7 @@ import "package:inventree/widget/company_detail.dart";
 import "package:inventree/widget/part_detail.dart";
 import "package:inventree/widget/progress.dart";
 import "package:inventree/widget/refreshable_state.dart";
+import 'package:inventree/widget/snacks.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 
@@ -34,6 +35,37 @@ class _SupplierPartDisplayState extends RefreshableState<SupplierPartDetailWidge
 
   @override
   String getAppBarTitle(BuildContext context) => L10().supplierPart;
+
+  @override
+  List<Widget> getAppBarActions(BuildContext context) {
+    List<Widget> actions = [];
+
+    actions.add(
+      IconButton(
+        icon: FaIcon(FontAwesomeIcons.edit),
+        tooltip: L10().edit,
+        onPressed: () {
+          editSupplierPart(context);
+        },
+      )
+    );
+
+    return actions;
+  }
+
+  /*
+   * Launch a form to edit the current SupplierPart instance
+   */
+  Future<void> editSupplierPart(BuildContext context) async {
+    widget.supplierPart.editForm(
+      context,
+      L10().supplierPartEdit,
+      onSuccess: (data) async {
+        refresh(context);
+        showSnackIcon(L10().supplierPartUpdated, success: true);
+      }
+    );
+  }
 
   @override
   Future<void> request(BuildContext context) async {

--- a/lib/widget/supplier_part_detail.dart
+++ b/lib/widget/supplier_part_detail.dart
@@ -1,10 +1,14 @@
 import "package:flutter/material.dart";
+import "package:font_awesome_flutter/font_awesome_flutter.dart";
 
+import "package:inventree/api.dart";
 import "package:inventree/l10.dart";
 
+import "package:inventree/inventree/part.dart";
 import "package:inventree/inventree/company.dart";
-import 'package:inventree/widget/progress.dart';
 
+import "package:inventree/widget/part_detail.dart";
+import "package:inventree/widget/progress.dart";
 import "package:inventree/widget/refreshable_state.dart";
 
 
@@ -47,6 +51,59 @@ class _SupplierPartDisplayState extends RefreshableState<SupplierPartDetailWidge
     if (loading) {
       tiles.add(progressIndicator());
       return tiles;
+    }
+
+    // Internal Part
+    tiles.add(
+        ListTile(
+          title: Text(widget.supplierPart.partName),
+          subtitle: Text(widget.supplierPart.partDescription),
+          leading: InvenTreeAPI().getImage(
+            widget.supplierPart.partImage,
+            width: 40,
+            height: 40,
+          ),
+          onTap: () async {
+            showLoadingOverlay(context);
+            final part = await InvenTreePart().get(widget.supplierPart.partId);
+            hideLoadingOverlay();
+
+            if (part is InvenTreePart) {
+              Navigator.push(context, MaterialPageRoute(
+                  builder: (context) => PartDetailWidget(part)));
+            }
+          },
+        )
+    );
+
+    // Supplier part details
+    tiles.add(
+      ListTile(
+        title: Text(widget.supplierPart.SKU),
+        subtitle: Text(widget.supplierPart.supplierName),
+        leading: FaIcon(FontAwesomeIcons.building),
+        trailing: InvenTreeAPI().getImage(
+          widget.supplierPart.supplierImage,
+          width: 40,
+          height: 40,
+        ),
+      )
+    );
+
+    // Manufacturer information
+    if (widget.supplierPart.manufacturerPartId > 0) {
+      tiles.add(
+        ListTile(
+          subtitle: Text(widget.supplierPart.manufacturerName),
+          title: Text(widget.supplierPart.MPN),
+          leading: FaIcon(FontAwesomeIcons.industry),
+          trailing: InvenTreeAPI().getImage(
+            widget.supplierPart.manufacturerImage,
+            width: 40,
+            height: 40,
+          )
+        )
+      );
     }
 
     return tiles;

--- a/lib/widget/supplier_part_detail.dart
+++ b/lib/widget/supplier_part_detail.dart
@@ -190,8 +190,7 @@ class _SupplierPartDisplayState extends RefreshableState<SupplierPartDetailWidge
 
     return tiles;
   }
-
-  @override
+  
   Widget getSelectedWidget(int index) {
     switch (index) {
       case 0:

--- a/lib/widget/supplier_part_detail.dart
+++ b/lib/widget/supplier_part_detail.dart
@@ -11,6 +11,7 @@ import "package:inventree/widget/company_detail.dart";
 import "package:inventree/widget/part_detail.dart";
 import "package:inventree/widget/progress.dart";
 import "package:inventree/widget/refreshable_state.dart";
+import 'package:url_launcher/url_launcher.dart';
 
 
 /*
@@ -114,6 +115,29 @@ class _SupplierPartDisplayState extends RefreshableState<SupplierPartDetailWidge
             width: 40,
             height: 40,
           )
+        )
+      );
+    }
+
+    if (widget.supplierPart.link.isNotEmpty) {
+      tiles.add(
+        ListTile(
+          title: Text(widget.supplierPart.link),
+          leading: FaIcon(FontAwesomeIcons.link),
+          onTap: () async {
+            if (await canLaunch(widget.supplierPart.link)) {
+              await launch(widget.supplierPart.link);
+            }
+          },
+        )
+      );
+    }
+
+    if (widget.supplierPart.note.isNotEmpty) {
+      tiles.add(
+        ListTile(
+          title: Text(widget.supplierPart.note),
+          leading: FaIcon(FontAwesomeIcons.pencilAlt),
         )
       );
     }

--- a/lib/widget/supplier_part_detail.dart
+++ b/lib/widget/supplier_part_detail.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:font_awesome_flutter/font_awesome_flutter.dart";
 
 import "package:inventree/api.dart";
+import 'package:inventree/barcode.dart';
 import "package:inventree/l10.dart";
 
 import "package:inventree/inventree/part.dart";
@@ -178,16 +179,60 @@ class _SupplierPartDisplayState extends RefreshableState<SupplierPartDetailWidge
   }
 
   /*
-   * Build the widget
+   * Return a list of actions which can be performed for this SupplierPart
    */
-  @override
-  Widget getBody(BuildContext context) {
-    return ListView(
-      children: ListTile.divideTiles(
-        context: context,
-        tiles: detailTiles(context),
-      ).toList()
+  List<Widget> actionTiles(BuildContext context) {
+    List<Widget> tiles = [];
+
+    tiles.add(
+      customBarcodeActionTile(context, this, widget.supplierPart.customBarcode, "supplierpart", widget.supplierPart.pk)
     );
+
+    return tiles;
   }
 
+  @override
+  Widget getSelectedWidget(int index) {
+    switch (index) {
+      case 0:
+        return ListView(
+            children: ListTile.divideTiles(
+              context: context,
+              tiles: detailTiles(context),
+            ).toList()
+        );
+      case 1:
+        return ListView(
+          children: ListTile.divideTiles(
+            context: context,
+            tiles: actionTiles(context)
+          ).toList()
+        );
+      default:
+        return ListView();
+    }
+  }
+
+  @override
+  Widget getBody(BuildContext context) {
+    return getSelectedWidget(tabIndex);
+  }
+
+  @override
+  Widget getBottomNavBar(BuildContext context) {
+    return BottomNavigationBar(
+      currentIndex: tabIndex,
+      onTap: onTabSelectionChanged,
+      items: [
+        BottomNavigationBarItem(
+          icon: FaIcon(FontAwesomeIcons.infoCircle),
+          label: L10().details,
+        ),
+        BottomNavigationBarItem(
+          icon: FaIcon(FontAwesomeIcons.wrench),
+          label: L10().actions
+        )
+      ]
+    );
+  }
 }

--- a/lib/widget/supplier_part_detail.dart
+++ b/lib/widget/supplier_part_detail.dart
@@ -190,7 +190,7 @@ class _SupplierPartDisplayState extends RefreshableState<SupplierPartDetailWidge
 
     return tiles;
   }
-  
+
   Widget getSelectedWidget(int index) {
     switch (index) {
       case 0:

--- a/lib/widget/supplier_part_detail.dart
+++ b/lib/widget/supplier_part_detail.dart
@@ -2,7 +2,7 @@ import "package:flutter/material.dart";
 import "package:font_awesome_flutter/font_awesome_flutter.dart";
 
 import "package:inventree/api.dart";
-import 'package:inventree/barcode.dart';
+import "package:inventree/barcode.dart";
 import "package:inventree/l10.dart";
 
 import "package:inventree/inventree/part.dart";
@@ -12,8 +12,8 @@ import "package:inventree/widget/company_detail.dart";
 import "package:inventree/widget/part_detail.dart";
 import "package:inventree/widget/progress.dart";
 import "package:inventree/widget/refreshable_state.dart";
-import 'package:inventree/widget/snacks.dart';
-import 'package:url_launcher/url_launcher.dart';
+import "package:inventree/widget/snacks.dart";
+import "package:url_launcher/url_launcher.dart";
 
 
 /*

--- a/lib/widget/supplier_part_detail.dart
+++ b/lib/widget/supplier_part_detail.dart
@@ -1,0 +1,68 @@
+import "package:flutter/material.dart";
+
+import "package:inventree/l10.dart";
+
+import "package:inventree/inventree/company.dart";
+import 'package:inventree/widget/progress.dart';
+
+import "package:inventree/widget/refreshable_state.dart";
+
+
+/*
+ * Detail widget for viewing a single SupplierPart instance
+ */
+class SupplierPartDetailWidget extends StatefulWidget {
+
+  const SupplierPartDetailWidget(this.supplierPart, {Key? key}) : super(key: key);
+
+  final InvenTreeSupplierPart supplierPart;
+
+  @override
+  _SupplierPartDisplayState createState() => _SupplierPartDisplayState();
+}
+
+
+class _SupplierPartDisplayState extends RefreshableState<SupplierPartDetailWidget> {
+
+  _SupplierPartDisplayState();
+
+  @override
+  String getAppBarTitle(BuildContext context) => L10().supplierPart;
+
+  @override
+  Future<void> request(BuildContext context) async {
+    final bool result = widget.supplierPart.pk > 0 && await widget.supplierPart.reload();
+
+    if (!result) {
+      Navigator.of(context).pop();
+    }
+  }
+
+  /*
+   * Build a set of tiles to display for this SupplierPart
+   */
+  List<Widget> detailTiles(BuildContext context) {
+    List<Widget> tiles = [];
+
+    if (loading) {
+      tiles.add(progressIndicator());
+      return tiles;
+    }
+
+    return tiles;
+  }
+
+  /*
+   * Build the widget
+   */
+  @override
+  Widget getBody(BuildContext context) {
+    return ListView(
+      children: ListTile.divideTiles(
+        context: context,
+        tiles: detailTiles(context),
+      ).toList()
+    );
+  }
+
+}

--- a/lib/widget/supplier_part_list.dart
+++ b/lib/widget/supplier_part_list.dart
@@ -1,0 +1,86 @@
+import "package:flutter/material.dart";
+
+import "package:inventree/l10.dart";
+
+import "package:inventree/inventree/company.dart";
+import "package:inventree/inventree/model.dart";
+
+import "package:inventree/widget/paginator.dart";
+import "package:inventree/widget/refreshable_state.dart";
+import "package:inventree/widget/supplier_part_detail.dart";
+
+
+/*
+ * Widget for displaying a list of Supplier Part instances
+ */
+class SupplierPartList extends StatefulWidget {
+
+  const SupplierPartList(this.filters);
+
+  final Map<String, String> filters;
+
+  @override
+  _SupplierPartListState createState() => _SupplierPartListState();
+}
+
+
+class _SupplierPartListState extends RefreshableState<SupplierPartList> {
+
+  @override
+  String getAppBarTitle(BuildContext context) => L10().supplierPart;
+
+  @override
+  Widget getBody(BuildContext  context) {
+    return PaginatedSupplierPartList(widget.filters);
+  }
+
+}
+
+
+class PaginatedSupplierPartList extends PaginatedSearchWidget {
+
+  const PaginatedSupplierPartList(Map<String, String> filters) : super(filters: filters);
+
+  @override
+  _PaginatedSupplierPartListState createState() => _PaginatedSupplierPartListState();
+
+}
+
+
+class _PaginatedSupplierPartListState extends PaginatedSearchState<PaginatedSupplierPartList> {
+
+  _PaginatedSupplierPartListState() : super();
+
+  @override
+  String get prefix => "supplierpart_";
+
+  @override
+  Map<String, String> get orderingOptions => {};
+
+  @override
+  Map<String, Map<String, dynamic>> get filterOptions => {};
+
+  @override
+  Future<InvenTreePageResponse?> requestPage(int limit, int offset, Map<String, String> params) async {
+    final page = await InvenTreeSupplierPart().listPaginated(limit, offset, filters: params);
+    return page;
+  }
+
+  @override
+  Widget buildItem(BuildContext context, InvenTreeModel model) {
+    InvenTreeSupplierPart supplierPart = model as InvenTreeSupplierPart;
+
+    return ListTile(
+      title: Text(supplierPart.SKU),
+      subtitle: Text(supplierPart.partName),
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => SupplierPartDetailWidget(supplierPart)
+          )
+        );
+      },
+    );
+  }
+}

--- a/lib/widget/supplier_part_list.dart
+++ b/lib/widget/supplier_part_list.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:font_awesome_flutter/font_awesome_flutter.dart";
 
 import "package:inventree/api.dart";
 import "package:inventree/l10.dart";
@@ -30,9 +31,23 @@ class _SupplierPartListState extends RefreshableState<SupplierPartList> {
   @override
   String getAppBarTitle(BuildContext context) => L10().supplierParts;
 
+  bool showFilterOptions = false;
+
+  @override
+  List<Widget> getAppBarActions(BuildContext context) => [
+    IconButton(
+      icon: FaIcon(FontAwesomeIcons.filter),
+      onPressed: () async {
+        setState(() {
+          showFilterOptions = !showFilterOptions;
+        });
+      },
+    )
+  ];
+
   @override
   Widget getBody(BuildContext  context) {
-    return PaginatedSupplierPartList(widget.filters);
+    return PaginatedSupplierPartList(widget.filters, showFilterOptions);
   }
 
 }
@@ -40,7 +55,7 @@ class _SupplierPartListState extends RefreshableState<SupplierPartList> {
 
 class PaginatedSupplierPartList extends PaginatedSearchWidget {
 
-  const PaginatedSupplierPartList(Map<String, String> filters) : super(filters: filters);
+  const PaginatedSupplierPartList(Map<String, String> filters, bool showSearch) : super(filters: filters, showSearch: showSearch);
 
   @override
   _PaginatedSupplierPartListState createState() => _PaginatedSupplierPartListState();

--- a/lib/widget/supplier_part_list.dart
+++ b/lib/widget/supplier_part_list.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 
+import "package:inventree/api.dart";
 import "package:inventree/l10.dart";
 
 import "package:inventree/inventree/company.dart";
@@ -27,7 +28,7 @@ class SupplierPartList extends StatefulWidget {
 class _SupplierPartListState extends RefreshableState<SupplierPartList> {
 
   @override
-  String getAppBarTitle(BuildContext context) => L10().supplierPart;
+  String getAppBarTitle(BuildContext context) => L10().supplierParts;
 
   @override
   Widget getBody(BuildContext  context) {
@@ -73,6 +74,16 @@ class _PaginatedSupplierPartListState extends PaginatedSearchState<PaginatedSupp
     return ListTile(
       title: Text(supplierPart.SKU),
       subtitle: Text(supplierPart.partName),
+      leading: InvenTreeAPI().getImage(
+        supplierPart.supplierImage,
+        width: 40,
+        height: 40
+      ),
+      trailing: InvenTreeAPI().getImage(
+        supplierPart.partImage,
+        width: 40,
+        height: 40,
+      ),
       onTap: () {
         Navigator.push(
           context,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inventree
 description: InvenTree stock management
 
-version: 0.9.3+53
+version: 0.10.0+54
 
 environment:
   sdk: ">=2.16.0 <3.0.0"


### PR DESCRIPTION
- Closes https://github.com/inventree/inventree-app/issues/246
- Closes https://github.com/inventree/inventree-app/issues/206
- Closes https://github.com/inventree/inventree-app/issues/8

This PR adds substantial support for managing Supplier Parts

- Integrate supplier part display into other screens
- View list of supplier parts (e.g. for a supplier, or a part)
- Scan supplier part barcode to open
- Add custom barcodes to supplier part instance