### PR TITLE
Fix iOS CI invalid syntax

### DIFF
--- a/.github/workflows/ios.yaml
+++ b/.github/workflows/ios.yaml
@@ -19,9 +19,9 @@ jobs:
         submodules: recursive
     - name: Setup Java
       uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '11'
+      with:
+        distribution: 'temurin'
+        java-version: '11'
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
       with:


### PR DESCRIPTION
Fixed a syntax error from #255 in the iOS workflow causing it to not run.