### PR TITLE
Bumped minimum iOS version to fix build

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your projects
-platform :ios, '9.0'
+platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -39,7 +39,7 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
     target.build_configurations.each do |config|
-      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '9.0'
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
     end
   end
 end

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -67,5 +67,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+	    <string>https</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This fixes the build error from `url_launcher` requiring a minimum of iOS 11.
I also added `LSApplicationQueriesSchemes` as iOS 14+ allows other browsers that require this.
A bump from 9 to 11 won't impact users really. https://iosref.com/ios-usage