### PR TITLE
Allow pausing camera barcode scanning

### DIFF
--- a/lib/barcode/camera_controller.dart
+++ b/lib/barcode/camera_controller.dart
@@ -29,13 +29,17 @@ class _CameraBarcodeControllerState extends InvenTreeBarcodeControllerState {
   QRViewController? _controller;
 
   bool flash_status = false;
+  bool processBarcode = true;
+  MaterialColor qrBorderColor = Colors.red;
 
   /* Callback function when the Barcode scanner view is initially created */
   void _onViewCreated(BuildContext context, QRViewController controller) {
     _controller = controller;
 
     controller.scannedDataStream.listen((barcode) {
-      handleBarcodeData(barcode.code);
+      if (processBarcode) {
+        handleBarcodeData(barcode.code);
+      }
     });
   }
 
@@ -122,18 +126,32 @@ class _CameraBarcodeControllerState extends InvenTreeBarcodeControllerState {
             Column(
               children: [
                 Expanded(
-                  child: QRView(
-                    key: barcodeControllerKey,
-                    onQRViewCreated: (QRViewController controller) {
-                      _onViewCreated(context, controller);
+                  child: Listener(
+                    onPointerDown: (details) {
+                      processBarcode = false;
+                      setState(() {
+                        qrBorderColor = Colors.green;
+                      });
                     },
-                    overlay: QrScannerOverlayShape(
-                      borderColor: Colors.red,
-                      borderRadius: 10,
-                      borderLength: 30,
-                      borderWidth: 10,
-                      cutOutSize: 300,
-                    ),
+                    onPointerUp: (details) {
+                      processBarcode = true;
+                      setState(() {
+                        qrBorderColor = Colors.red;
+                      });
+                    },
+                    child: QRView(
+                      key: barcodeControllerKey,
+                      onQRViewCreated: (QRViewController controller) {
+                        _onViewCreated(context, controller);
+                      },
+                      overlay: QrScannerOverlayShape(
+                        borderColor: Colors.red,
+                        borderRadius: 10,
+                        borderLength: 30,
+                        borderWidth: 10,
+                        cutOutSize: 300,
+                      ),
+                    )
                   )
                 )
               ]


### PR DESCRIPTION
Pause camera barcode scanning while touching the screen, scan frame border turns green to indicate that.

This is because I have some sorting boxes for which I print sheets with the content for the lid so you can see what is in the box.
When I started with InvenTree I added the stock item QR codes to that sheet. Here is an example:
<img width="925" alt="image" src="https://github.com/inventree/inventree-app/assets/6394581/8fb4c33d-99aa-4cd7-a64e-6da2a633bbff">

But it is hard to scan a code surrounded by other codes, so I need some mechanism to stop scanning without stopping the camera picture updating to target a specific QR code.

No idea if this is the way to do it, suggestions for improvements welcome 😄 .