### PR TITLE
ERROR if 'flutter pub get' is done before 'invoke translate'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ We use the [invoke](https://www.pyinvoke.org) to run some core tasks - you will 
 
 Initial project setup (after you have installed all required dev tools) is as follows:
 
-Install required flutter packages:
-```
-flutter pub get
-```
-
 Generate initial translation files:
 
 ```
 invoke translate
+```
+
+Install required flutter packages:
+```
+flutter pub get
 ```
 
 You should now be ready to debug on a connected or emulated device!


### PR DESCRIPTION
If you run `flutter pub get` before `invoke translate`, you get this error:

```bash
Generating synthetic localizations package failed with 1 error:

Exception: The 'arb-dir' directory, 'LocalDirectory: '[path\to\project]\lib/l10n/collected'', does not exist.    
Make sure that the correct path was provided.
```

If you run `invoke translate` then `flutter pub get`, the error is gone.