### PR TITLE
Move function return to correct line on scan success

### DIFF
--- a/lib/barcode/stock.dart
+++ b/lib/barcode/stock.dart
@@ -44,8 +44,8 @@ class BarcodeScanStockLocationHandler extends BarcodeHandler {
 
         if (result && OneContext.hasContext) {
           OneContext().pop();
-          return;
         }
+        return;
       }
     }
 


### PR DESCRIPTION
This is a quick change to resolve Issue #520 - the function return statement was inside an if block it shouldn't have been, resulting on both the scan success and scan failure user feedback events firing when scanning a StockItem into a location.