### PR TITLE
Update barcode scan pause instruction text

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -148,7 +148,7 @@
   "barcodeScanPaused": "Barcode scanning paused",
   "@barodeScanPaused": {},
 
-  "barcodeScanPause": "Tap or hold to pause scanning",
+  "barcodeScanPause": "Tap to pause scanning",
   "@barcodeScanPause": {},
 
   "barcodeScanAssign": "Scan to assign barcode",


### PR DESCRIPTION
As lined out in #720 the text describes a functionality which does not work anymore due to the changes of the barcode scanning since it has been introduced.