### PR TITLE
Improve Sales Order UX: Stock Location, Customer Filtering & Enhanced List View

### DIFF
--- a/lib/api_form.dart
+++ b/lib/api_form.dart
@@ -732,6 +732,7 @@ class APIFormField {
 
         return ListTile(
           title: Text(item.partName),
+          subtitle: Text(item.locationPathString),
           leading: InvenTreeAPI().getThumbnail(item.partThumbnail),
           trailing: Text(item.quantityString()),
         );

--- a/lib/inventree/sales_order.dart
+++ b/lib/inventree/sales_order.dart
@@ -48,7 +48,7 @@ class InvenTreeSalesOrder extends InvenTreeOrder {
     Map<String, Map<String, dynamic>> fields = {
       "reference": {},
       "customer": {
-        "filters": {"is_customer": true},
+        "filters": {"is_customer": true, "active": true},
       },
       "customer_reference": {},
       "description": {},

--- a/lib/widget/order/sales_order_list.dart
+++ b/lib/widget/order/sales_order_list.dart
@@ -151,9 +151,15 @@ class _PaginatedSalesOrderListState
 
     InvenTreeCompany? customer = order.customer;
 
+    // Build subtitle with customer name and optional total price
+    String subtitle = customer?.name ?? order.description;
+    if (order.totalPrice != null && order.totalPrice! > 0) {
+      subtitle += " • ${order.totalPriceCurrency} ${order.totalPrice!.toStringAsFixed(2)}";
+    }
+
     return ListTile(
       title: Text(order.reference),
-      subtitle: Text(order.description),
+      subtitle: Text(subtitle),
       leading: customer == null
           ? null
           : InvenTreeAPI().getThumbnail(customer.thumbnail),

--- a/lib/widget/order/sales_order_list.dart
+++ b/lib/widget/order/sales_order_list.dart
@@ -154,7 +154,8 @@ class _PaginatedSalesOrderListState
     // Build subtitle with customer name and optional total price
     String subtitle = customer?.name ?? order.description;
     if (order.totalPrice != null && order.totalPrice! > 0) {
-      subtitle += " • ${order.totalPriceCurrency} ${order.totalPrice!.toStringAsFixed(2)}";
+      subtitle +=
+          " • ${order.totalPriceCurrency} ${order.totalPrice!.toStringAsFixed(2)}";
     }
 
     return ListTile(

--- a/lib/widget/order/so_allocation_list.dart
+++ b/lib/widget/order/so_allocation_list.dart
@@ -55,10 +55,11 @@ class _PaginatedSOAllocationListState
 
     InvenTreePart? part = allocation.part;
     InvenTreeStockItem? stockItem = allocation.stockItem;
+    InvenTreeStockLocation? location = allocation.location;
 
     return ListTile(
       title: Text(part?.fullname ?? ""),
-      subtitle: Text(part?.description ?? ""),
+      subtitle: Text(location?.pathstring ?? L10().locationNotSet),
       onTap: () async {
         stockItem?.goToDetailPage(context);
       },


### PR DESCRIPTION
## Summary

This PR addresses three usability issues in the Sales Order workflow that improve the day-to-day experience for warehouse and field staff.

1. https://github.com/inventree/inventree-app/issues/751
2. https://github.com/inventree/inventree-app/issues/750
3. https://github.com/inventree/inventree-app/issues/752

## Changes

### 1. Show Stock Location When Allocating Items
**File:** `lib/api_form.dart`

When allocating stock to a sales order, the stock item picker now displays the **location path** below each item name. This allows users to quickly identify which physical stock they're selecting without cross-referencing other screens.

**Before:** Only part name and quantity shown
**After:** Part name, location path, and quantity shown

---

### 2. Filter Inactive Customers from Selection
**File:** `lib/inventree/sales_order.dart`

The customer selection dropdown now filters out **inactive customers**, matching the behavior of the web platform. This prevents accidentally creating orders for deactivated accounts.

**Change:** Added `"active": true` filter to the customer field.

---

### 3. Enhanced Sales Order List View
**File:** `lib/widget/order/sales_order_list.dart`

The sales order list now shows more useful information at a glance:
- **Customer name** (instead of just order description)
- **Order total** with currency (when available)
- Status badge remains visible

This allows staff to quickly identify orders without opening each one individually.

---

## Testing

All changes tested on Android emulator:
- ✅ Stock allocation picker shows location
- ✅ Inactive customers not shown in dropdown
- ✅ Order list displays customer name and total
