### PR TITLE
Improve scan stock item in Issue 617

### DIFF
--- a/assets/release_notes.md
+++ b/assets/release_notes.md
@@ -1,6 +1,7 @@
-## 0.24.4 - June 2026
+## 0.25.0 - July 2026
 ---
 
+- API speed improvements
 - Enable scanning of Build Order barcodes
 - Updated translations
 

--- a/lib/api.dart
+++ b/lib/api.dart
@@ -479,10 +479,7 @@ class InvenTreeAPI {
       url = url + "/";
     }
 
-    // Cache the "strictHttps" setting, so we can use it later without async requirement
-    _strictHttps =
-        await InvenTreeSettingsManager().getValue(INV_STRICT_HTTPS, false)
-            as bool;
+    await _refreshHttpsPolicy();
 
     debug("Connecting to ${apiUrl}");
 
@@ -565,6 +562,8 @@ class InvenTreeAPI {
     debug("Fetching user token from ${userProfile.server}");
 
     profile = userProfile;
+
+    await _refreshHttpsPolicy();
 
     // Form a name to request the token with
     String platform_name = "inventree-mobile-app";
@@ -657,6 +656,8 @@ class InvenTreeAPI {
     _connected = false;
     _connecting = false;
     profile = null;
+
+    _resetHttpClient();
 
     // Clear received settings
     _globalSettings.clear();
@@ -930,17 +931,11 @@ class InvenTreeAPI {
 
     HttpClientRequest? _request;
 
-    final bool strictHttps =
-        await InvenTreeSettingsManager().getValue(INV_STRICT_HTTPS, false)
-            as bool;
-
-    var client = createClient(url, strictHttps: strictHttps);
-
     showLoadingOverlay();
 
     // Attempt to open a connection to the server
     try {
-      _request = await client
+      _request = await httpClient
           .openUrl("GET", _uri)
           .timeout(Duration(seconds: 10));
 
@@ -1013,14 +1008,6 @@ class InvenTreeAPI {
     String method = "POST",
     Map<String, dynamic>? fields,
   }) async {
-    bool strictHttps = await InvenTreeSettingsManager().getBool(
-      INV_STRICT_HTTPS,
-      false,
-    );
-
-    // Create an IOClient wrapper for sending the MultipartRequest
-    final ioClient = IOClient(createClient(url, strictHttps: strictHttps));
-
     final uri = Uri.parse(makeApiUrl(url));
     final request = http.MultipartRequest(method, uri);
 
@@ -1050,9 +1037,9 @@ class InvenTreeAPI {
     String jsondata = "";
 
     try {
-      var streamedResponse = await ioClient
-          .send(request)
-          .timeout(Duration(seconds: 120));
+      var streamedResponse = await IOClient(
+        httpClient,
+      ).send(request).timeout(Duration(seconds: 120));
       final httpResponse = await http.Response.fromStream(streamedResponse);
 
       response.statusCode = httpResponse.statusCode;
@@ -1198,14 +1185,14 @@ class InvenTreeAPI {
    * Note that for some instances, we may wish to ignore certificate errors (e.g. self-signed certificates)
    * In this case, we will allow the user to disable "strict HTTPS" mode
    */
-  HttpClient createClient(String url, {bool strictHttps = true}) {
-    var client = HttpClient();
+  HttpClient _createClient() {
+    HttpClient client = HttpClient();
 
     client.badCertificateCallback =
         (X509Certificate cert, String host, int port) {
-          if (strictHttps) {
+          if (_strictHttps) {
             showServerError(
-              url,
+              "${host}:${port}",
               L10().serverCertificateError,
               L10().serverCertificateInvalid,
             );
@@ -1220,6 +1207,40 @@ class InvenTreeAPI {
     client.connectionTimeout = Duration(seconds: 30);
 
     return client;
+  }
+
+  /*
+   * Cached, reusable HttpClient instance.
+   * Avoids doing a slow TCP + TLS handshake on each request.
+   */
+  HttpClient? _httpClient;
+
+  HttpClient get httpClient {
+    return _httpClient ??= _createClient();
+  }
+
+  void _resetHttpClient() {
+    _httpClient?.close(force: true);
+    _httpClient = null;
+    _imageCacheManager = null;
+  }
+
+  /*
+   * Notify the API that the "strictHttps" setting has been changed.
+   */
+  void onStrictHttpsChanged(bool strictHttps) {
+    if (strictHttps != _strictHttps) {
+      _strictHttps = strictHttps;
+      _resetHttpClient();
+    }
+  }
+
+  Future<void> _refreshHttpsPolicy() async {
+    final bool strictHttps =
+        await InvenTreeSettingsManager().getValue(INV_STRICT_HTTPS, false)
+            as bool;
+
+    onStrictHttpsChanged(strictHttps);
   }
 
   /*
@@ -1265,15 +1286,9 @@ class InvenTreeAPI {
 
     HttpClientRequest? _request;
 
-    final bool strictHttps =
-        await InvenTreeSettingsManager().getValue(INV_STRICT_HTTPS, false)
-            as bool;
-
-    var client = createClient(url, strictHttps: strictHttps);
-
     // Attempt to open a connection to the server
     try {
-      _request = await client
+      _request = await httpClient
           .openUrl(method, _uri)
           .timeout(Duration(seconds: 10));
 
@@ -1593,12 +1608,6 @@ class InvenTreeAPI {
 
     String url = makeUrl(imageUrl);
 
-    const key = "inventree_network_image";
-
-    CacheManager manager = CacheManager(
-      Config(key, fileService: InvenTreeFileService(strictHttps: _strictHttps)),
-    );
-
     return CachedNetworkImage(
       imageUrl: url,
       placeholder: (context, url) => CircularProgressIndicator(),
@@ -1614,7 +1623,21 @@ class InvenTreeAPI {
       httpHeaders: defaultHeaders(),
       height: height,
       width: width,
-      cacheManager: manager,
+      cacheManager: imageCacheManager,
+    );
+  }
+
+  CacheManager? _imageCacheManager;
+
+  CacheManager get imageCacheManager {
+    return _imageCacheManager ??= CacheManager(
+      Config(
+        "inventree_network_image",
+        fileService: InvenTreeFileService(
+          client: httpClient,
+          strictHttps: _strictHttps,
+        ),
+      ),
     );
   }
 

--- a/lib/barcode/stock.dart
+++ b/lib/barcode/stock.dart
@@ -75,27 +75,31 @@ class BarcodeScanStockItemHandler extends BarcodeHandler {
     if (data.containsKey("stockitem")) {
       int _item = (data["stockitem"]?["pk"] ?? -1) as int;
 
-      // A valid stock location!
       if (_item > 0) {
         barcodeSuccessTone();
 
-        bool result = await onItemScanned(_item);
+        await onItemScanned(_item);
+      }
+    }else if (data.containsKey("stocklocation")) {
+      int _loc = (data["stocklocation"]?["pk"] ?? -1) as int;
 
-        if (result && OneContext.hasContext) {
-          OneContext().pop();
-          return;
-        }
+      if (_loc > 0) {
+        barcodeSuccessTone();
+
+        await onStockLocationScanned(_loc);
       }
     }
 
-    // If we get to this point, something went wrong during the scan process
-    barcodeFailureTone();
-
-    showSnackIcon(L10().invalidStockItem, success: false);
   }
 
   // Callback function which runs when a valid StockItem is scanned
   Future<bool> onItemScanned(int itemId) async {
+    // Re-implement this for particular subclass
+    return false;
+  }
+
+  // Callback function which runs when a valid StockLocation is scanned
+  Future<bool> onStockLocationScanned(int locationId) async {
     // Re-implement this for particular subclass
     return false;
   }
@@ -172,6 +176,55 @@ class StockLocationScanInItemsHandler extends BarcodeScanStockItemHandler {
   String getOverlayText(BuildContext context) => L10().barcodeScanItem;
 
   @override
+  Future<bool> onStockLocationScanned(int locationId) async {
+    if (locationId == location.pk) {
+      barcodeFailureTone();
+      showSnackIcon(L10().invalidStockLocation, success: false);
+      return false;
+    }
+
+    final scannedLocation =
+        await InvenTreeStockLocation().get(locationId) as InvenTreeStockLocation?;
+
+    if (scannedLocation != null) {
+      if (scannedLocation.parentId == location.pk) {
+        barcodeFailureTone();
+        showSnackIcon(L10().itemInLocation, success: false);
+        return false;
+      }
+
+      final response = await scannedLocation.update(
+        values: {"parent": location.pk.toString()},
+        expectedStatusCode: null,
+      );
+
+      switch (response.statusCode) {
+        case 200:
+        case 201:
+          barcodeSuccess(L10().barcodeScanIntoLocationSuccess);
+          return true;
+        case 400:
+          barcodeFailureTone();
+          showSnackIcon(L10().invalidStockLocation, success: false);
+          return false;
+        default:
+          barcodeFailureTone();
+          showSnackIcon(
+            L10().barcodeScanIntoLocationFailure,
+            success: false,
+            actionText: L10().details,
+            onAction: () {
+              showErrorDialog(L10().barcodeError, response: response);
+            },
+          );
+          return false;
+      }
+    }
+
+    return false;
+  }
+
+  @override
   Future<bool> onItemScanned(int itemId) async {
     final InvenTreeStockItem? item =
         await InvenTreeStockItem().get(itemId) as InvenTreeStockItem?;
@@ -186,7 +239,7 @@ class StockLocationScanInItemsHandler extends BarcodeScanStockItemHandler {
       // Item is already *in* the specified location
       if (item.locationId == location.pk) {
         barcodeFailureTone();
-        showSnackIcon(L10().itemInLocation, success: true);
+        showSnackIcon(L10().itemInLocation, success: false);
         return false;
       } else {
         if (confirm) {

--- a/lib/barcode/stock.dart
+++ b/lib/barcode/stock.dart
@@ -80,7 +80,7 @@ class BarcodeScanStockItemHandler extends BarcodeHandler {
 
         await onItemScanned(_item);
       }
-    }else if (data.containsKey("stocklocation")) {
+    } else if (data.containsKey("stocklocation")) {
       int _loc = (data["stocklocation"]?["pk"] ?? -1) as int;
 
       if (_loc > 0) {
@@ -89,7 +89,6 @@ class BarcodeScanStockItemHandler extends BarcodeHandler {
         await onStockLocationScanned(_loc);
       }
     }
-
   }
 
   // Callback function which runs when a valid StockItem is scanned
@@ -184,7 +183,8 @@ class StockLocationScanInItemsHandler extends BarcodeScanStockItemHandler {
     }
 
     final scannedLocation =
-        await InvenTreeStockLocation().get(locationId) as InvenTreeStockLocation?;
+        await InvenTreeStockLocation().get(locationId)
+            as InvenTreeStockLocation?;
 
     if (scannedLocation != null) {
       if (scannedLocation.parentId == location.pk) {

--- a/lib/settings/app_settings.dart
+++ b/lib/settings/app_settings.dart
@@ -274,6 +274,7 @@ class _InvenTreeAppSettingsState extends State<InvenTreeAppSettingsWidget> {
                 value: strictHttps,
                 onChanged: (bool value) {
                   InvenTreeSettingsManager().setValue(INV_STRICT_HTTPS, value);
+                  InvenTreeAPI().onStrictHttpsChanged(value);
                   setState(() {
                     strictHttps = value;
                   });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: inventree
 description: InvenTree stock management
 
-version: 0.24.4+122
+version: 0.25.0+123
 
 environment:
   sdk: ^3.8.1


### PR DESCRIPTION
Resolves https://github.com/inventree/inventree-app/issues/617

This PR enhances the "Scan In Items" workflow by introducing continuous scanning, support for location scanning, and fixing several UX notification bugs.

**Enhancements:**
- **Support scanning stock locations:** In addition to stock items, users can now scan stock location barcodes in the "Scan In Items" flow. Scanning a valid stock location will automatically re-parent it under the current location via the API.
- **Enable continuous scanning:** The scanner no longer closes automatically after a successful scan. Removed the `OneContext().pop()` call and the blanket failure tone/message at the end of `processBarcode`, allowing users to scan multiple items uninterrupted.

**Fixes:**
- **Accurate "already in location" notification:** Changed `showSnackIcon` from `success: true` to `success: false` for this specific case. It now correctly displays an error indicator when a user attempts to move an item to its current location.
- **Fixed notification collision bug:** Addressed an issue where `onBarcodeMatched` would show a default error message if `onItemScanned` returned false, which inadvertently overrode successful notifications. Notification UI handling is now properly delegated to `onStockLocationScanned` and `onItemScanned`.